### PR TITLE
本番、開発、テストのRDBMSの設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "rails", "~> 8.0.2"
 # The modern asset pipeline for Rails [https://github.com/rails/propshaft]
 gem "propshaft"
 # Use pg as the database for Active Record
-gem "pg", "~> 1.1"
+# gem "pg", "~> 1.1"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 # Use JavaScript with ESM import maps [https://github.com/rails/importmap-rails]
@@ -43,6 +43,8 @@ gem "thruster", require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
+  # Use sqlite3 as the database for Active Record
+  gem "sqlite3"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
@@ -60,4 +62,9 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+end
+
+group :production do
+  # Use PstgreSQL as the database for Active Record
+  gem "pg", "~> 1.1"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,6 +297,8 @@ GEM
       fugit (~> 1.11.0)
       railties (>= 7.1)
       thor (>= 1.3.1)
+    sqlite3 (2.7.3-x64-mingw-ucrt)
+    sqlite3 (2.7.3-x86_64-linux-gnu)
     sshkit (1.24.0)
       base64
       logger
@@ -358,6 +360,7 @@ DEPENDENCIES
   solid_cable
   solid_cache
   solid_queue
+  sqlite3
   stimulus-rails
   thruster
   turbo-rails

--- a/render.yaml
+++ b/render.yaml
@@ -1,20 +1,21 @@
 services:
   - type: web
-    name: sample_matchingapp_db
+    name: sample_matching_app_db
     runtime: ruby
+    region: oregon
     plan: free
     buildCommand: "./bin/render-build.sh"
     startCommand: "./bin/rails server"
     envVars:
       - key: DATABASE_URL
         fromDatabase:
-          name: sample_matchingapp_db
+          name: sample_matching_app_db
           property: connectionString
       - key: RAILS_MASTER_KEY
         sync: false
       - key: WEB_CONCURRENCY
         value: 2
 databases:
-  - name: sample_matchingapp_db
+  - name: sample_matching_app_db
     plan: free
     


### PR DESCRIPTION
## 見てほしいところ・伝えたいこと
公式ドキュメントよりも、Qiitaなどの記事の方が render.yamlの書き方の情報量は充実していた。

## 変更の概要
①gem "pg" が重複しているので　１つにした。
②開発は sqlite3 を使用するように。 
③render.yamlに regionキー を追加。値は oregon

## なぜこの変更をするのか
* 変更をする理由
①gem "pg" が重複しているとエラー。
②開発は sqlite3 を使用したいため。開発のためにpostgresqlのDBを作るのは面倒くさい。
③多くの記事で regionキーをしていたため。
 参考：https://qiita.com/ysk91_engineer/items/b7db950f4739fa896f57

* 前提知識がなくても分かるようにする


## やったこと
①gem "pg" をコメントアウト
①grop production do で本番環境だけ posgresql を使用するように。
②gem "sqlite3" でデフォルトのRDBMSに sqlite3 を設定。
③ render.yaml に regionキーの追記


## 変更内容
* 主な変更点
①Gemfile の gem "pg" をコメントアウト、gem "sqlite3" を追記、
grop production do 
  gem "pg"
end
を追記

②render.yaml に regionキーの追記



* UIの変更ならスクリーンショット

* APIの変更ならリクエストとレスポンス


## 影響範囲
* ユーザーに影響すること
すべてのユーザーに影響

* メンバーに影響すること

* システムに影響すること


## どうやるのか
* 使い方
設定の段階なので、ユーザーは特になにもしなくてよい。

* 再現手順

## 課題
* 悩んでいること

* とくにレビューしてほしいところ

## 備考
* その他に伝えたいこと