### PR TITLE
アカウント作成時の画像投稿

### DIFF
--- a/app/controllers/user_informations_controller.rb
+++ b/app/controllers/user_informations_controller.rb
@@ -5,7 +5,12 @@ class UserInformationsController < ApplicationController
 
   def create
     @user_information = UserInformation.new(user_information_params)
-    @user_information.image.attach(io: File.open("app/assets/images/defaultUserIcon.png"), filename: "defaultUserIcon.png", content_type: "image/png")
+    if @user_information.image.attached?
+      # binding.pry
+    else
+      # binding.pry
+      @user_information.image.attach(io: File.open("app/assets/images/defaultUserIcon.png"), filename: "defaultUserIcon.png", content_type: "image/png")
+    end
     if @user_information.save
       redirect_to users_path
     else
@@ -15,7 +20,7 @@ class UserInformationsController < ApplicationController
 
   private
   def user_information_params
-    params.require(:user_information).permit(:age, :birth_date, :prefecture_id, :hobby_id).merge(user_id: current_user.id)
     # binding.pry
+    params.require(:user_information).permit(:image, :age, :birth_date, :prefecture_id, :hobby_id).merge(user_id: current_user.id)
   end
 end

--- a/app/views/user_informations/new.html.erb
+++ b/app/views/user_informations/new.html.erb
@@ -1,5 +1,7 @@
 <h3>ユーザープロフィール作成</h3>
 <%= form_with model: @user_information, url: create_user_information_path, local: true, data: { turbo: false } do |f| %>
+  <%= f.label :image, "アイコンにする画像をアップロードしてください。"%></br>
+  <%= f.file_field :image %></br>
   <%= f.label :age, "あなたの年齢を選択してください" %></br>
   <%= f.number_field :age, autocomplete: "off", value: 18 %></br>
 


### PR DESCRIPTION
## 見てほしいところ・伝えたいこと
とくになし。

## 変更の概要
①アカウント作成時にユーザーがアカウント画像を選択したら、その画像を保存。
選択しなかったら、デフォルト画像を保存。
②ビューでは保存されている画像を表示。

* なぜこれを実装するのか
ユーザーを表示たびに、if文でアイコン画像があるか判定するよりも、最初からデフォルトのアイコン画像を設定しておいたほうが、処理数が少ないため。

## 変更内容
* 主な変更点
①attachメソッドで、user_informatinテーブルに画像を追加。
②ストロングパラメータの修正。
③ビューの修正。

* APIの変更ならリクエストとレスポンス


## なぜこの変更をするのか
①画像をviewを介さず、controllerから直接、追加するには、attachメソッドがあると調べたため。
* やったこと
インスタンス変数にattachメソッドで画像を追加。
調べ方： デフォルト画像
参考：https://railsguides.jp/active_storage_overview.html#file-io-objects%E3%82%92%E3%82%A2%E3%82%BF%E3%83%83%E3%83%81%E3%81%99%E3%82%8B

②formから画像を渡す必要がなくなったため。
* やったこと
permitのimageカラムを削除。

③formから画像を渡す必要がなくなったため。
* やったこと
f.file_field :image を削除。

* 前提知識がなくても分かるようにする


## 影響範囲
* ユーザーに影響すること
すべてのユーザーに影響

* メンバーに影響すること

* システムに影響すること


## どうやるのか
* 使い方
アカウントを作成すれば、自動的に画像が保存される。

* 再現手順

## 課題
* 悩んでいること

* 反省
画像の保存方法について調べていたが、最初からactive_storageについて調べていれば
もっと早く実装できたかも

* とくにレビューしてほしいところ

## 備考
* その他に伝えたいこと