### PR TITLE
【確認求】退会機能修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,7 +2,7 @@ class UsersController < ApplicationController
   skip_before_action :authenticate_user!, only: [:new, :cancel_membership]
 
   def index
-    @users = User.all
+    @users = User.where(deleted_at: nil)
   end
 
   def new

--- a/app/javascript/countdown.js
+++ b/app/javascript/countdown.js
@@ -19,21 +19,16 @@ var user_data = {
   endTime: endTime
 }
 
-var serializedArray = localStorage.getItem('myArray');
-var array = JSON.parse(serializedArray);
+var already_user = JSON.parse(localStorage.getItem('myArray'));
 
-function users(user_data) {
-  return user_data.email === email && user_data.deleted_at === deleted_at;
-}
-
-if (array.find(users)) {
-  var target_user_data = array.find(users);
-  var endTime = target_user_data.endTime;
+if (already_user) {
+  if(already_user.email === email && already_user.deleted_at === deleted_at) {
+    var endTime = already_user.endTime;
+  } else {
+    localStorage.setItem('myArray', JSON.stringify(user_data));
+  } 
 } else {
-  const user_data_array = [];
-  user_data_array.push(user_data);
-  const serializedArray = JSON.stringify(user_data_array);
-  localStorage.setItem('myArray', serializedArray);
+  localStorage.setItem('myArray', JSON.stringify(user_data));
 }
 
 function updateCountDown(){

--- a/app/javascript/countdown.js
+++ b/app/javascript/countdown.js
@@ -1,9 +1,9 @@
-const countDown = document.getElementById("seconds");
-const message = document.getElementById("message");
-const email = document.getElementById("email").textContent;
-const deleted_at = document.getElementById("deleted_at").textContent;
+var countDown = document.getElementById("seconds");
+var message = document.getElementById("message");
+var email = document.getElementById("email").textContent;
+var deleted_at = document.getElementById("deleted_at").textContent;
 
-let targetTime = countDown.textContent;
+var targetTime = countDown.textContent;
 targetTime = parseInt(targetTime);
 targetMinitues = Math.floor(targetTime / 60);
 targetSeconds = targetTime % 60;
@@ -13,45 +13,27 @@ targetTime.setMinutes(targetTime.getMinutes() + targetMinitues);
 targetTime.setSeconds(targetTime.getSeconds() + targetSeconds);
 var endTime = targetTime.getTime();
 
-//そもそもの設計がおかしい気がする。
-//更新するごとにendTimeが変化していないか？今の時間から+されてる？
-//↓やっぱりそう。
 console.log(endTime);
 
-let user_data = {
+var user_data = {
   email: email,
   deleted_at: deleted_at,
   endTime: endTime
 }
 
-// //endTimeが更新しても変わらないように保存してみる
-// const user_data_array = [];
-// user_data_array.push(user_data);
-// const serializedArray = JSON.stringify(user_data_array);
-// localStorage.setItem('myArray', serializedArray);
-
-// //更新しても変わらないか調べる。
-// console.log(localStorage.getItem('myArray'));
-
-// //更新されるたびに再代入されてendTimeが更新されてる。
-
-// //だからlocalStorageにあったら再代入しないようにしよう。
 const serializedArray = localStorage.getItem('myArray');
 const array = JSON.parse(serializedArray);
-
 
 function users(user_data) {
   return user_data.email === email && user_data.deleted_at === deleted_at;
 }
 
-// if (array){
+if (array){
   if (array.find(users)) {
     console.log("true array.find");
     var target_user_data = array.find(users);
     console.log(target_user_data.endTime);
-    console.log(array);
     var endTime = target_user_data.endTime;
-    // console.log(array.find(users));
   } else {
     console.log("false array.find");
     const user_data_array = [];
@@ -59,27 +41,27 @@ function users(user_data) {
     const serializedArray = JSON.stringify(user_data_array);
     localStorage.setItem('myArray', serializedArray);
   }
-// } else {
-//   console.log("false array");
-//   const user_data_array = [];
-//   user_data_array.push(user_data);
-//   const serializedArray = JSON.stringify(user_data_array);
-//   localStorage.setItem('myArray', serializedArray);
-// }
+} else {
+  console.log("false array");
+  const user_data_array = [];
+  user_data_array.push(user_data);
+  const serializedArray = JSON.stringify(user_data_array);
+  localStorage.setItem('myArray', serializedArray);
+}
 
-// function updateCountDown(){
-//   const now = new Date().getTime();
-//   const distance = endTime - now;
+function updateCountDown(){
+  const now = new Date().getTime();
+  const distance = endTime - now;
 
-//   const minutes = Math.floor(distance % (1000 * 60 * 60) / (1000 * 60));
-//   const seconds = Math.floor(distance % (1000 * 60) / 1000);
+  const minutes = Math.floor(distance % (1000 * 60 * 60) / (1000 * 60));
+  const seconds = Math.floor(distance % (1000 * 60) / 1000);
 
-//   countDown.textContent = `${String(minutes)}分 ${String(seconds)}秒`;
+  countDown.textContent = `${String(minutes)}分 ${String(seconds)}秒`;
 
-//   if(distance < 0){
-//     clearInterval(interval);
-//     message.textContent = "再度、新規登録できます。";
-//   }
-// }
-// const interval = setInterval(updateCountDown, 1000);
-// updateCountDown();
+  if(distance < 0){
+    clearInterval(interval);
+    message.textContent = "再度、新規登録できます。";
+  }
+}
+const interval = setInterval(updateCountDown, 1000);
+updateCountDown();

--- a/app/javascript/countdown.js
+++ b/app/javascript/countdown.js
@@ -1,63 +1,85 @@
-window.onload = function(){
-  const countDown = document.getElementById("seconds");
-  const message = document.getElementById("message");
-  const email = document.getElementById("email").textContent;
-  const deleted_at = document.getElementById("deleted_at").textContent;
+const countDown = document.getElementById("seconds");
+const message = document.getElementById("message");
+const email = document.getElementById("email").textContent;
+const deleted_at = document.getElementById("deleted_at").textContent;
 
-  let targetTime = countDown.textContent;
-  targetTime = parseInt(targetTime);
-  targetMinitues = Math.floor(targetTime / 60);
-  targetSeconds = targetTime % 60;
+let targetTime = countDown.textContent;
+targetTime = parseInt(targetTime);
+targetMinitues = Math.floor(targetTime / 60);
+targetSeconds = targetTime % 60;
 
-  targetTime = new Date();
-  targetTime.setMinutes(targetTime.getMinutes() + targetMinitues);
-  targetTime.setSeconds(targetTime.getSeconds() + targetSeconds);
-  let endTime = targetTime.getTime();
+targetTime = new Date();
+targetTime.setMinutes(targetTime.getMinutes() + targetMinitues);
+targetTime.setSeconds(targetTime.getSeconds() + targetSeconds);
+var endTime = targetTime.getTime();
 
-  let user_data = {
-    email: email,
-    deleted_at: deleted_at,
-    endTime: endTime
-  }
+//そもそもの設計がおかしい気がする。
+//更新するごとにendTimeが変化していないか？今の時間から+されてる？
+//↓やっぱりそう。
+console.log(endTime);
 
-  function users(user_data) {
-	  return user_data.email === email && user_data.deleted_at === deleted_at;
-  }
+let user_data = {
+  email: email,
+  deleted_at: deleted_at,
+  endTime: endTime
+}
 
-  const serializedArray2 = localStorage.getItem('myArray');
-  const array = JSON.parse(serializedArray2);
+// //endTimeが更新しても変わらないように保存してみる
+// const user_data_array = [];
+// user_data_array.push(user_data);
+// const serializedArray = JSON.stringify(user_data_array);
+// localStorage.setItem('myArray', serializedArray);
 
-  if (array){
-    if (array.find(users)) {
-      var target_user_data = array.find(users);
-      endTime = target_user_data.endTime;
-    } else {
-      const user_data_array = [];
-      user_data_array.push(user_data);
-      const serializedArray = JSON.stringify(user_data_array);
-      localStorage.setItem('myArray', serializedArray);
-    }
+// //更新しても変わらないか調べる。
+// console.log(localStorage.getItem('myArray'));
+
+// //更新されるたびに再代入されてendTimeが更新されてる。
+
+// //だからlocalStorageにあったら再代入しないようにしよう。
+const serializedArray = localStorage.getItem('myArray');
+const array = JSON.parse(serializedArray);
+
+
+function users(user_data) {
+  return user_data.email === email && user_data.deleted_at === deleted_at;
+}
+
+// if (array){
+  if (array.find(users)) {
+    console.log("true array.find");
+    var target_user_data = array.find(users);
+    console.log(target_user_data.endTime);
+    console.log(array);
+    var endTime = target_user_data.endTime;
+    // console.log(array.find(users));
   } else {
+    console.log("false array.find");
     const user_data_array = [];
     user_data_array.push(user_data);
     const serializedArray = JSON.stringify(user_data_array);
     localStorage.setItem('myArray', serializedArray);
   }
+// } else {
+//   console.log("false array");
+//   const user_data_array = [];
+//   user_data_array.push(user_data);
+//   const serializedArray = JSON.stringify(user_data_array);
+//   localStorage.setItem('myArray', serializedArray);
+// }
 
-  function updateCountDown(){
-    const now = new Date().getTime();
-    const distance = endTime - now;
+// function updateCountDown(){
+//   const now = new Date().getTime();
+//   const distance = endTime - now;
 
-    const minutes = Math.floor(distance % (1000 * 60 * 60) / (1000 * 60));
-    const seconds = Math.floor(distance % (1000 * 60) / 1000);
+//   const minutes = Math.floor(distance % (1000 * 60 * 60) / (1000 * 60));
+//   const seconds = Math.floor(distance % (1000 * 60) / 1000);
 
-    countDown.textContent = `${String(minutes)}分 ${String(seconds)}秒`;
+//   countDown.textContent = `${String(minutes)}分 ${String(seconds)}秒`;
 
-    if(distance < 0){
-      clearInterval(interval);
-      message.textContent = "再度、新規登録できます。";
-    }
-  }
-  const interval = setInterval(updateCountDown, 1000);
-  updateCountDown();
-}
+//   if(distance < 0){
+//     clearInterval(interval);
+//     message.textContent = "再度、新規登録できます。";
+//   }
+// }
+// const interval = setInterval(updateCountDown, 1000);
+// updateCountDown();

--- a/app/javascript/countdown.js
+++ b/app/javascript/countdown.js
@@ -13,36 +13,23 @@ targetTime.setMinutes(targetTime.getMinutes() + targetMinitues);
 targetTime.setSeconds(targetTime.getSeconds() + targetSeconds);
 var endTime = targetTime.getTime();
 
-console.log(endTime);
-
 var user_data = {
   email: email,
   deleted_at: deleted_at,
   endTime: endTime
 }
 
-const serializedArray = localStorage.getItem('myArray');
-const array = JSON.parse(serializedArray);
+var serializedArray = localStorage.getItem('myArray');
+var array = JSON.parse(serializedArray);
 
 function users(user_data) {
   return user_data.email === email && user_data.deleted_at === deleted_at;
 }
 
-if (array){
-  if (array.find(users)) {
-    console.log("true array.find");
-    var target_user_data = array.find(users);
-    console.log(target_user_data.endTime);
-    var endTime = target_user_data.endTime;
-  } else {
-    console.log("false array.find");
-    const user_data_array = [];
-    user_data_array.push(user_data);
-    const serializedArray = JSON.stringify(user_data_array);
-    localStorage.setItem('myArray', serializedArray);
-  }
+if (array.find(users)) {
+  var target_user_data = array.find(users);
+  var endTime = target_user_data.endTime;
 } else {
-  console.log("false array");
   const user_data_array = [];
   user_data_array.push(user_data);
   const serializedArray = JSON.stringify(user_data_array);
@@ -63,5 +50,5 @@ function updateCountDown(){
     message.textContent = "再度、新規登録できます。";
   }
 }
-const interval = setInterval(updateCountDown, 1000);
+var interval = setInterval(updateCountDown, 1000);
 updateCountDown();


### PR DESCRIPTION
## 見てほしいところ・伝えたいこと

## 仕様
①ユーザーごとに次に新規登録できるまでのカウントダウンを設けています。
②ブラウザを更新してもカウントダウンの数値はリセットされません。
* 前提知識がなくても分かるようにする

* APIの変更ならリクエストとレスポンス

## 画面
* ユーザー退会画面

https://github.com/user-attachments/assets/acedd828-ce75-4619-933b-117fefcf9890

## 修正
①コンフリフトのミスの修正。
②const を var に変更。
③リロード時・再度サイトを開いたときのユーザーデータの取り出し方法。

* なぜこの変更をしたのか？
②同じ端末で複数のアカウントで退会したり、同じメールアドレスのアカウントで複数回退会すると、定数の再定義エラ
　ーとなるため。

③複雑な配列を使用しなくても、対応できたため。

## 影響範囲
* ユーザーに影響すること
すべてのユーザーに影響

* メンバーに影響すること

* システムに影響すること


## どうやるのか
* 使い方

* 再現手順


## 課題
* 悩んでいること

* 反省

* とくにレビューしてほしいところ


## 備考
* その他に伝えたいこと
